### PR TITLE
Ignore BSP directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ temp
 /OPAL/bi/src/test/fixtures-java/rt-jar-stubs-1.8.0-works.jar
 .bloop/
 .metals/
+.bsp
 
 # Exclude .jvmopts as this specifies custom sbt launching options
 .jvmopts


### PR DESCRIPTION
The latest SBT creates a directory for the Build Server Protocol. The file in there contains local information, thus should be ignored.