### PR TITLE
Full support for VarHandle

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/MethodDescriptor.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/MethodDescriptor.scala
@@ -483,14 +483,24 @@ object MethodDescriptor {
     }
 
     /**
-     * The signature of a signature polymorphic method.
-     * Basically, the signature:
+     * The signatures of a signature polymorphic method.
+     * Basically, the signature is one of:
      * {{{
      *      (params: Object[]) : Object
+     *      (params: Object[]) : void
+     *      (params: Object[]) : boolean
      * }}}
      */
-    final val SignaturePolymorphicMethod: MethodDescriptor = {
+    final val SignaturePolymorphicMethodObject: MethodDescriptor = {
         new SingleArgumentMethodDescriptor(ArrayType.ArrayOfObject, ObjectType.Object)
+    }
+
+    final val SignaturePolymorphicMethodVoid: MethodDescriptor = {
+        new SingleArgumentMethodDescriptor(ArrayType.ArrayOfObject, VoidType)
+    }
+
+    final val SignaturePolymorphicMethodBoolean: MethodDescriptor = {
+        new SingleArgumentMethodDescriptor(ArrayType.ArrayOfObject, BooleanType)
     }
 
     final val JustReturnsBoolean: MethodDescriptor = new NoArgumentMethodDescriptor(BooleanType)

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethodsKey.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethodsKey.scala
@@ -7,10 +7,12 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.{Function ⇒ JFunction}
 
-import org.opalj.br.MethodDescriptor.SignaturePolymorphicMethod
 import org.opalj.br.ObjectType.MethodHandle
 import org.opalj.br.ObjectType.VarHandle
 import org.opalj.collection.immutable.ConstArray
+import org.opalj.br.MethodDescriptor.SignaturePolymorphicMethodBoolean
+import org.opalj.br.MethodDescriptor.SignaturePolymorphicMethodObject
+import org.opalj.br.MethodDescriptor.SignaturePolymorphicMethodVoid
 
 /**
  * The ''key'' object to get information about all declared methods.
@@ -88,7 +90,7 @@ object DeclaredMethodsKey extends ProjectInformationKey[DeclaredMethods, Nothing
         def insertDeclaredMethod(
             dms:                   ConcurrentHashMap[MethodContext, DeclaredMethod],
             context:               MethodContext,
-            computeDeclaredMethod: (Int) ⇒ DeclaredMethod
+            computeDeclaredMethod: Int ⇒ DeclaredMethod
         ): Unit = {
             val oldDm = dms.computeIfAbsent(context, _ ⇒ computeDeclaredMethod(
                 idCounter.getAndIncrement()
@@ -213,21 +215,31 @@ object DeclaredMethodsKey extends ProjectInformationKey[DeclaredMethods, Nothing
         }
 
         // Special handling for signature-polymorphic methods
-        if (p.classFile(MethodHandle).isEmpty) {
+        if (p.MethodHandleClassFile.isEmpty) {
             val dms = result.computeIfAbsent(MethodHandle, _ ⇒ new ConcurrentHashMap)
             for (name ← methodHandleSignaturePolymorphicMethods) {
-                val context = new MethodContext(name, SignaturePolymorphicMethod)
+                val context = new MethodContext(name, SignaturePolymorphicMethodObject)
                 insertDeclaredMethod(dms, context, id ⇒ new VirtualDeclaredMethod(
-                    MethodHandle, name, SignaturePolymorphicMethod, id
+                    MethodHandle, name, SignaturePolymorphicMethodObject, id
                 ))
             }
         }
-        if (p.classFile(VarHandle).isEmpty) {
+        if (p.VarHandleClassFile.isEmpty) {
             val dms = result.computeIfAbsent(VarHandle, _ ⇒ new ConcurrentHashMap)
             for (name ← varHandleSignaturePolymorphicMethods) {
-                val context = new MethodContext(name, SignaturePolymorphicMethod)
+                val descriptor = if (name == "compareAndSet" || name.startsWith("weak"))
+                    SignaturePolymorphicMethodBoolean
+                else if (name.startsWith("set"))
+                    SignaturePolymorphicMethodVoid
+                else if (name.startsWith("get") || name.startsWith("compare"))
+                    SignaturePolymorphicMethodObject
+                else
+                    throw new IllegalArgumentException(
+                        s"Unexpected signature polymorphic method $name"
+                    )
+                val context = new MethodContext(name, descriptor)
                 insertDeclaredMethod(dms, context, id ⇒ new VirtualDeclaredMethod(
-                    VarHandle, name, SignaturePolymorphicMethod, id
+                    VarHandle, name, descriptor, id
                 ))
             }
         }
@@ -353,17 +365,17 @@ object DeclaredMethodsKey extends ProjectInformationKey[DeclaredMethods, Nothing
                 packageName == that.packageName &&
                     methodName == that.methodName &&
                     descriptor == that.descriptor &&
-                    !hasAccessibleMethod()
+                    !hasAccessibleMethod
             case that: ShadowsPackagePrivateMethodContext ⇒
                 methodName == that.methodName &&
                     descriptor == that.descriptor &&
-                    hasAccessibleMethod()
+                    hasAccessibleMethod
             case that: MethodContext ⇒
                 methodName == that.methodName && descriptor == that.descriptor
             case _ ⇒ false
         }
 
-        private def hasAccessibleMethod(): Boolean = {
+        private def hasAccessibleMethod: Boolean = {
             if (project.classHierarchy.isInterface(receiverType).isYes) {
                 val method =
                     project.resolveInterfaceMethodReference(receiverType, methodName, descriptor)

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
@@ -140,6 +140,7 @@ class Project[Source] private (
         final val libraryFieldsCount:                 Int,
         final val codeSize:                           Long,
         final val MethodHandleSubtypes:               Set[ObjectType],
+        final val VarHandleSubtypes:                  Set[ObjectType],
         final val classFilesCount:                    Int,
         final val methodsCount:                       Int,
         final val fieldsCount:                        Int,
@@ -205,6 +206,7 @@ class Project[Source] private (
             libraryFieldsCount,
             codeSize,
             MethodHandleSubtypes,
+            VarHandleSubtypes,
             classFilesCount,
             methodsCount,
             fieldsCount,
@@ -236,6 +238,8 @@ class Project[Source] private (
     final val ObjectClassFile: Option[ClassFile] = classFile(ObjectType.Object)
 
     final val MethodHandleClassFile: Option[ClassFile] = classFile(ObjectType.MethodHandle)
+
+    final val VarHandleClassFile: Option[ClassFile] = classFile(ObjectType.VarHandle)
 
     final val allMethodsWithBody: ConstArray[Method] = ConstArray._UNSAFE_from(this.methodsWithBody)
 
@@ -2089,6 +2093,10 @@ object Project {
                 classHierarchy.allSubtypes(ObjectType.MethodHandle, reflexive = true)
             }
 
+            val VarHandleSubtypes = {
+                classHierarchy.allSubtypes(ObjectType.VarHandle, reflexive = true)
+            }
+
             val classFilesCount: Int = projectClassFilesCount + libraryClassFilesCount
 
             val methodsCount: Int = projectMethodsCount + libraryMethodsCount
@@ -2137,6 +2145,7 @@ object Project {
                 libraryFieldsCount,
                 codeSize,
                 MethodHandleSubtypes,
+                VarHandleSubtypes,
                 classFilesCount,
                 methodsCount,
                 fieldsCount,


### PR DESCRIPTION
There was some initial support for java.lang.invoke.VarHandle signature polymorphic methods before, but it was incorrect and not implemented in all places. This is fixed now.