### PR TITLE
Enforce invokedynamic rewriting for the respective test

### DIFF
--- a/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/br/InvokedynamicRewritingExecutionTest.scala
+++ b/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/br/InvokedynamicRewritingExecutionTest.scala
@@ -15,6 +15,7 @@ import org.opalj.bytecode.RTJar
 import org.opalj.bi.TestResources.locateTestResources
 import org.opalj.bi.isCurrentJREAtLeastJava9
 import org.opalj.br.analyses.Project
+import org.opalj.br.reader.InvokedynamicRewriting
 import org.opalj.ba.ProjectBasedInMemoryClassLoader
 import org.opalj.bc.Assembler
 import org.opalj.io.JARsFileFilter
@@ -30,8 +31,12 @@ import org.opalj.util.InMemoryClassLoader
 class InvokedynamicRewritingExecutionTest extends FunSpec with Matchers {
 
     def JavaFixtureProject(fixtureFiles: File): Project[URL] = {
+        implicit val config = InvokedynamicRewriting.defaultConfig(
+            rewrite = true,
+            logRewrites = false
+        )
 
-        val projectClassFiles = Project.JavaClassFileReader().ClassFiles(fixtureFiles)
+        val projectClassFiles = Project.JavaClassFileReader.ClassFiles(fixtureFiles)
         val libraryClassFiles = Project.JavaLibraryClassFileReader.ClassFiles(RTJar)
 
         info(s"the test fixture project consists of ${projectClassFiles.size} class files")

--- a/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/br/InvokedynamicRewritingExecutionTest.scala
+++ b/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/br/InvokedynamicRewritingExecutionTest.scala
@@ -11,6 +11,8 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 
+import com.typesafe.config.Config
+
 import org.opalj.bytecode.RTJar
 import org.opalj.bi.TestResources.locateTestResources
 import org.opalj.bi.isCurrentJREAtLeastJava9
@@ -31,7 +33,7 @@ import org.opalj.util.InMemoryClassLoader
 class InvokedynamicRewritingExecutionTest extends FunSpec with Matchers {
 
     def JavaFixtureProject(fixtureFiles: File): Project[URL] = {
-        implicit val config = InvokedynamicRewriting.defaultConfig(
+        implicit val config: Config = InvokedynamicRewriting.defaultConfig(
             rewrite = true,
             logRewrites = false
         )
@@ -134,7 +136,7 @@ class InvokedynamicRewritingExecutionTest extends FunSpec with Matchers {
             val p = JavaFixtureProject(r)
             val cf = p.classFile(testClassType).get.copy(version = bi.Java8Version)
             val inMemoryClassLoader =
-                new InMemoryClassLoader(Map(testClassType.toJava -> Assembler(ba.toDA(cf))))
+                new InMemoryClassLoader(Map(testClassType.toJava → Assembler(ba.toDA(cf))))
 
             it("simpleConcat should concatenate strings correctly") {
                 val c = inMemoryClassLoader.loadClass(testClassType.toJava)


### PR DESCRIPTION
This fixes the test picking up a config that may have rewriting disabled