### PR TITLE
Prevent TACAI on aborted AI Result

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/TACAI.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/TACAI.scala
@@ -128,6 +128,9 @@ object TACAI {
         optimizations: List[TACOptimization[TACMethodParameter, DUVar[aiResult.domain.DomainValue], AITACode[TACMethodParameter, aiResult.domain.DomainValue]]]
     ): AITACode[TACMethodParameter, aiResult.domain.DomainValue] = {
 
+        if (aiResult.wasAborted)
+            throw new IllegalArgumentException("cannot create TACAI from aborted AI result")
+
         val domain: aiResult.domain.type = aiResult.domain
         val operandsArray: aiResult.domain.OperandsArray = aiResult.operandsArray
         val localsArray: aiResult.domain.LocalsArray = aiResult.localsArray


### PR DESCRIPTION
When AI is aborted, the RecordDefUseDomain does not collect the necessary data for TAC creation. This leads exceptions that are hard to understand. Instead, fail early and with a clear message that TAC on aborted AI Results is not supported.