### PR TITLE
Improved tests for equality for set based integer domains

### DIFF
--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerSetValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerSetValues.scala
@@ -304,6 +304,18 @@ trait IntegerSetValues
                 else
                     Unknown
 
+            case (IntegerSet(vs), btbs: BaseTypesBasedSet) ⇒
+                if (vs forall { v ⇒ v < btbs.lowerBound || v > btbs.upperBound })
+                    No
+                else
+                    Unknown
+
+            case (btbs: BaseTypesBasedSet, IntegerSet(vs)) ⇒
+                if (vs forall { v ⇒ v < btbs.lowerBound || v > btbs.upperBound })
+                    No
+                else
+                    Unknown
+
             case _ ⇒
                 Unknown
         }


### PR DESCRIPTION
Evaluate whether equality is possible for BaseTypeBased sets to prevent impossible assignments.

(Not having this had a value representing a char (0-65535) set to because it was deemed to be possible that it had that value.)