### PR TITLE
Provide method to get proper TAC instruction at PC

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/Stmt.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/Stmt.scala
@@ -83,6 +83,7 @@ sealed abstract class Stmt[+V <: Var[V]] extends ASTNode[V] {
     def isNonVirtualMethodCall: Boolean = false
     def isVirtualMethodCall: Boolean = false
     def isStaticMethodCall: Boolean = false
+    def isCaughtException: Boolean = false
 
 }
 
@@ -1106,6 +1107,7 @@ case class CaughtException[+V <: Var[V]](
         private var throwingStmts: IntTrieSet
 ) extends Stmt[V] {
 
+    final override def isCaughtException: Boolean = true
     final override def asCaughtException: CaughtException[V] = this
     final override def astID: Int = CaughtException.ASTID
     final override def forallSubExpressions[W >: V <: Var[W]](p: Expr[W] ⇒ Boolean): Boolean = true

--- a/OPAL/tac/src/main/scala/org/opalj/tac/common/DefinitionSite.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/common/DefinitionSite.scala
@@ -23,7 +23,7 @@ case class DefinitionSite(method: Method, pc: Int) extends DefinitionSiteLike {
     override def usedBy[V <: ValueInformation](
         tacode: TACode[TACMethodParameter, DUVar[V]]
     ): IntTrieSet = {
-        val defSite = tacode.pcToIndex(pc)
+        val defSite = tacode.properStmtIndexForPC(pc)
         if (defSite == -1) {
             // the code is dead
             IntTrieSet.empty

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
@@ -223,7 +223,7 @@ class FieldLocalityAnalysis private[analyses] (
         val field = state.field
         val fieldName = field.name
         val fieldType = field.fieldType
-        val index = tacai.pcToIndex(pc)
+        val index = tacai.properStmtIndexForPC(pc)
 
         if (index < 0)
             return true; // access is dead
@@ -710,13 +710,13 @@ final case class DefinitionSiteWithoutPutField(
     override def usedBy[V <: ValueInformation](
         tacode: TACode[TACMethodParameter, DUVar[V]]
     ): IntTrieSet = {
-        val defSite = tacode.pcToIndex(pc)
+        val defSite = tacode.properStmtIndexForPC(pc)
         if (defSite == -1) {
             // the code is dead
             IntTrieSet.empty
         } else {
             val Assignment(_, dvar, _) = tacode.stmts(defSite)
-            dvar.usedBy - tacode.pcToIndex(putFieldPC)
+            dvar.usedBy - tacode.properStmtIndexForPC(putFieldPC)
         }
     }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/L1FieldMutabilityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/L1FieldMutabilityAnalysis.scala
@@ -176,7 +176,7 @@ class L1FieldMutabilityAnalysis private[analyses] (val project: SomeProject) ext
     ): Boolean = {
         val stmts = taCode.stmts
         for (pc ← pcs) {
-            val index = taCode.pcToIndex(pc)
+            val index = taCode.properStmtIndexForPC(pc)
             if (index >= 0) {
                 val stmtCandidate = stmts(index)
                 if (stmtCandidate.pc == pc) {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIBasedAPIBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIBasedAPIBasedAnalysis.scala
@@ -48,7 +48,7 @@ trait TACAIBasedAPIBasedAnalysis extends APIBasedAnalysis {
     )(tacEOptP: SomeEOptionP): ProperPropertyComputationResult = tacEOptP match {
         case UBPS(tac: TheTACAI, isFinal) ⇒
             val theTAC = tac.theTAC
-            val callStmt = theTAC.stmts(theTAC.pcToIndex(pc))
+            val callStmt = theTAC.stmts(theTAC.properStmtIndexForPC(pc))
             val call = retrieveCall(callStmt)
             val tgtVarOpt =
                 if (callStmt.isAssignment)
@@ -83,10 +83,12 @@ trait TACAIBasedAPIBasedAnalysis extends APIBasedAnalysis {
     ): ProperPropertyComputationResult = {
         val tac = tacEPS.ub.tac.get
         val callees = calleesEPS.ub
-        val receiverOption = callees.indirectCallReceiver(pc, apiMethod).map(uVarForDefSites(_, tac.pcToIndex))
-        val params = callees.indirectCallParameters(pc, apiMethod).map(_.map(uVarForDefSites(_, tac.pcToIndex)))
+        val receiverOption =
+            callees.indirectCallReceiver(pc, apiMethod).map(uVarForDefSites(_, tac.pcToIndex))
+        val params =
+            callees.indirectCallParameters(pc, apiMethod).map(_.map(uVarForDefSites(_, tac.pcToIndex)))
 
-        val callStmt = tac.stmts(tac.pcToIndex(pc))
+        val callStmt = tac.stmts(tac.properStmtIndexForPC(pc))
         val tgtVarOpt =
             if (callStmt.isAssignment)
                 Some(callStmt.asAssignment.targetVar)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedPointsToCGAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedPointsToCGAnalysis.scala
@@ -82,7 +82,7 @@ abstract class AbstractDoPrivilegedPointsToCGAnalysis private[cg] (
             caller, FinalEP(caller.definedMethod, TheTACAI(tac))
         )
 
-        val StaticFunctionCallStatement(call) = tac.stmts(tac.pcToIndex(pc))
+        val StaticFunctionCallStatement(call) = tac.stmts(tac.properStmtIndexForPC(pc))
 
         val actualParamDefSites = call.params.head.asVar.definedBy
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedThreadRelatedCallsAnalysisScheduler.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedThreadRelatedCallsAnalysisScheduler.scala
@@ -69,10 +69,13 @@ trait PointsToBasedThreadStartAnalysis
     ): ProperPropertyComputationResult = {
         val indirectCalls = new IndirectCalls()
 
-        implicit val state: State = new PointsToBasedCGState[PointsToSet](caller, FinalEP(caller.definedMethod, TheTACAI(tac)))
+        implicit val state: State = new PointsToBasedCGState[PointsToSet](
+            caller, FinalEP(caller.definedMethod, TheTACAI(tac))
+        )
 
         if (isDirect) {
-            val receiver = tac.stmts(state.tac.pcToIndex(pc)).asInstanceMethodCall.receiver
+            val receiver =
+                tac.stmts(state.tac.properStmtIndexForPC(pc)).asInstanceMethodCall.receiver
             handleStart(caller, receiver, pc, indirectCalls)
         } else
             indirectCalls.addIncompleteCallSite(pc)
@@ -108,8 +111,9 @@ trait PointsToBasedThreadStartAnalysis
 
                 for (cs ← relevantCallSites) {
                     val pc = cs._1
-                    val receiver =
-                        state.tac.stmts(state.tac.pcToIndex(pc)).asInstanceMethodCall.receiver
+                    val receiver = state.tac.stmts(
+                        state.tac.properStmtIndexForPC(pc)
+                    ).asInstanceMethodCall.receiver
                     ub.forNewestNTypes(ub.numTypes - seenTypes) { newType ⇒
                         val theType = newType.asObjectType
                         handleType(
@@ -172,7 +176,7 @@ trait PointsToBasedThreadStartAnalysis
             pc,
             "start",
             MethodDescriptor.NoArgsAndReturnVoid,
-            state.tac.stmts(state.tac.pcToIndex(pc)).asInstanceMethodCall.declaringClass
+            state.tac.stmts(state.tac.properStmtIndexForPC(pc)).asInstanceMethodCall.declaringClass
         )
 
         // get the upper bound of the pointsToSet and creates a dependency if needed

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
@@ -475,7 +475,7 @@ class MethodHandleInvokeAnalysis private[analyses] (
     ): ProperPropertyComputationResult = {
         implicit val indirectCalls: IndirectCalls = new IndirectCalls()
         val descriptorOpt = if (isDirect && apiMethod.name == "invokeExact") {
-            tac.stmts(tac.pcToIndex(pc)) match {
+            tac.stmts(tac.properStmtIndexForPC(pc)) match {
                 case vmc: VirtualMethodCall[V]          ⇒ Some(vmc.descriptor)
                 case VirtualFunctionCallStatement(call) ⇒ Some(call.descriptor)
             }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
@@ -302,7 +302,7 @@ final class TypePropagationAnalysis private[analyses] (
         partialResults: ListBuffer[SomePartialResult]
     ): Unit = {
         val returnValueIsUsed = {
-            val tacIndex = state.tac.pcToIndex(pc)
+            val tacIndex = state.tac.properStmtIndexForPC(pc)
             val tacInstr = state.tac.instructions(tacIndex)
             tacInstr.isAssignment
         }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysisState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysisState.scala
@@ -112,7 +112,7 @@ trait AbstractEscapeAnalysisState {
 
         context.entity match {
             case ds: DefinitionSiteLike ⇒
-                _defSite = tacai.pcToIndex(ds.pc)
+                _defSite = tacai.properStmtIndexForPC(ds.pc)
                 _uses = ds.usedBy(tacai)
 
             case fp: VirtualFormalParameter ⇒

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ArraycopyPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ArraycopyPointsToAnalysis.scala
@@ -73,7 +73,7 @@ abstract class ArraycopyPointsToAnalysis private[pointsto] ( final val project: 
         val targetArr = params(2)
 
         if (sourceArr.isDefined && targetArr.isDefined) {
-            val index = tac.pcToIndex(pc)
+            val index = tac.properStmtIndexForPC(pc)
 
             handleArrayLoad(
                 ArrayType.ArrayOfObject, pc, sourceArr.get.asVar.definedBy, checkForCast = false

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
@@ -98,7 +98,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis {
     )(implicit state: State): ReferenceType ⇒ Boolean = {
         if (checkForCast) {
             val tac = state.tac
-            val index = tac.pcToIndex(pc)
+            val index = tac.properStmtIndexForPC(pc)
             val nextStmt = tac.stmts(index + 1)
             nextStmt match {
                 case Checkcast(_, value, cmpTpe) if value.asVar.definedBy.contains(index) ⇒

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/AbstractPurityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/AbstractPurityAnalysis.scala
@@ -80,8 +80,7 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
         val method: Method
         val definedMethod: DeclaredMethod
         val declClass: ObjectType
-        var pcToIndex: Array[Int]
-        var code: Array[Stmt[V]]
+        var tac: TACode[TACMethodParameter, V]
     }
 
     type StateType <: AnalysisState
@@ -147,7 +146,7 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
             }
         }
 
-        val stmt = state.code(origin)
+        val stmt = state.tac.stmts(origin)
         (stmt.astID: @switch) match {
             case StaticMethodCall.ASTID ⇒ false // We are looking for implicit exceptions only
 
@@ -175,7 +174,7 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
         call:     Call[V],
         receiver: Option[Expr[V]]
     )(implicit state: StateType): Boolean = {
-        implicit val code: Array[Stmt[V]] = state.code
+        implicit val code: Array[Stmt[V]] = state.tac.stmts
         val ratedResult = rater.handleCall(call, receiver)
         if (ratedResult.isDefined)
             atMost(ratedResult.get)
@@ -231,7 +230,7 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
                     origin ← stmt.asCaughtException.origins
                     if isImmediateVMException(origin)
                 } {
-                    val baseOrigin = state.code(ai.underlyingPC(origin))
+                    val baseOrigin = state.tac.stmts(ai.underlyingPC(origin))
                     val ratedResult = rater.handleException(baseOrigin)
                     if (ratedResult.isDefined) atMost(ratedResult.get)
                     else atMost(SideEffectFree)
@@ -269,7 +268,7 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
             // Field/array loads are pure if the field is (effectively) final or the object/array is
             // local and non-escaping
             case GetStatic.ASTID ⇒
-                implicit val code: Array[Stmt[V]] = state.code
+                implicit val code: Array[Stmt[V]] = state.tac.stmts
                 val ratedResult = rater.handleGetStatic(expr.asGetStatic)
                 if (ratedResult.isDefined) atMost(ratedResult.get)
                 else checkPurityOfFieldRef(expr.asGetStatic)
@@ -314,32 +313,12 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
         }
     }
 
-    def getCall(stmt: Stmt[V])(implicit state: StateType): Call[V] = stmt.astID match {
+    def getCall(stmt: Stmt[V]): Call[V] = stmt.astID match {
         case StaticMethodCall.ASTID     ⇒ stmt.asStaticMethodCall
         case NonVirtualMethodCall.ASTID ⇒ stmt.asNonVirtualMethodCall
         case VirtualMethodCall.ASTID    ⇒ stmt.asVirtualMethodCall
         case Assignment.ASTID           ⇒ stmt.asAssignment.expr.asFunctionCall
         case ExprStmt.ASTID             ⇒ stmt.asExprStmt.expr.asFunctionCall
-        case CaughtException.ASTID ⇒
-            /*
-             * There is no caught exception instruction in bytecode, so it might be the case, that
-             * in the three-address code, there is a CaughtException stmt right before the call
-             * with the same pc. Therefore, we have to get the call stmt after the current stmt.
-             *
-             * Example:
-             * void foo() {
-             *     try {
-             *         ...
-             *     } catch (Exception e) {
-             *         e.printStackTrace();
-             *     }
-             * }
-             *
-             * In TAC:
-             * 12: pc=52 caught java.lang.Exception ...
-             * 13: pc=52 java.lang.Exception.printStackTrace()
-             */
-            getCall(state.code(state.pcToIndex(stmt.pc) + 1))
         case _ ⇒
             throw new IllegalStateException(s"unexpected stmt $stmt")
     }
@@ -511,11 +490,11 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
 
                 val hasIncompleteCallSites =
                     p.incompleteCallSites.exists { pc ⇒
-                        val index = state.pcToIndex(pc)
+                        val index = state.tac.properStmtIndexForPC(pc)
                         if (index < 0)
                             false // call will not be executed
                         else {
-                            val call = getCall(state.code(state.pcToIndex(pc)))
+                            val call = getCall(state.tac.stmts(index))
                             !isDomainSpecificCall(call, call.receiverOption)
                         }
                     }
@@ -527,11 +506,11 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
 
                 val noDirectCalleeIsImpure = p.directCallSites().forall {
                     case (pc, callees) ⇒
-                        val index = state.pcToIndex(pc)
+                        val index = state.tac.properStmtIndexForPC(pc)
                         if (index < 0)
                             true // call will not be executed
                         else {
-                            val call = getCall(state.code(index))
+                            val call = getCall(state.tac.stmts(index))
                             isDomainSpecificCall(call, call.receiverOption) ||
                                 callees.forall { callee ⇒
                                     checkPurityOfMethod(
@@ -547,19 +526,21 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
 
                 val noIndirectCalleeIsImpure = p.indirectCallSites().forall {
                     case (pc, callees) ⇒
-                        val index = state.pcToIndex(pc)
+                        val index = state.tac.properStmtIndexForPC(pc)
                         if (index < 0)
                             true // call will not be executed
                         else {
-                            val call = getCall(state.code(index))
+                            val call = getCall(state.tac.stmts(index))
                             isDomainSpecificCall(call, call.receiverOption) ||
                                 callees.forall { callee ⇒
                                     checkPurityOfMethod(
                                         callee,
                                         p.indirectCallReceiver(pc, callee).map(receiver ⇒
-                                            uVarForDefSites(receiver, state.pcToIndex)).orNull +:
-                                            p.indirectCallParameters(pc, callee).map { paramO ⇒
-                                                paramO.map(uVarForDefSites(_, state.pcToIndex)).orNull
+                                            uVarForDefSites(receiver, state.tac.pcToIndex)).orNull
+                                            +: p.indirectCallParameters(pc, callee).map { paramO ⇒
+                                                paramO.map(
+                                                    uVarForDefSites(_, state.tac.pcToIndex)
+                                                ).orNull
                                             }
                                     )
                                 }

--- a/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/jcg/Reflection.scala
+++ b/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/jcg/Reflection.scala
@@ -139,7 +139,7 @@ class Reflection(implicit hermes: HermesConfig) extends DefaultFeatureQuery {
                 case i @ INVOKESTATIC(ClassT, false, "forName", ForName1MD | ForName3MD) ⇒ i
             }
         } {
-            val TACode(_, stmts, pcToIndex, _, _) = try {
+            val tac = try {
                 tacai(method)
             } catch {
                 case e: Exception ⇒
@@ -151,11 +151,11 @@ class Reflection(implicit hermes: HermesConfig) extends DefaultFeatureQuery {
             val l = InstructionLocation(methodLocation, pc)
 
             if (pcAndInstruction.value.isMethodInvocationInstruction) {
-                implicit val body: Array[Stmt[V]] = stmts
+                implicit val body: Array[Stmt[V]] = tac.stmts
 
-                val index = pcToIndex(pc)
+                val index = tac.properStmtIndexForPC(pc)
                 if (index != -1) {
-                    val stmt = stmts(index)
+                    val stmt = tac.stmts(index)
 
                     val call =
                         if (stmt.astID == Assignment.ASTID) stmt.asAssignment.expr.asFunctionCall
@@ -482,9 +482,10 @@ class Reflection(implicit hermes: HermesConfig) extends DefaultFeatureQuery {
             if (invokes.isEmpty) {
                 false
             } else {
-                val TACode(_, stmts, pcToIndex, _, _) = tacai(method)
+                val tac = tacai(method)
+                val stmts = tac.stmts
                 invokes.exists { pcAndInvocation ⇒
-                    val stmt = stmts(pcToIndex(pcAndInvocation.pc))
+                    val stmt = stmts(tac.properStmtIndexForPC(pcAndInvocation.pc))
                     val call =
                         if (stmt.astID == Assignment.ASTID)
                             stmt.asAssignment.expr.asVirtualFunctionCall

--- a/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/jcg/Serialization.scala
+++ b/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/jcg/Serialization.scala
@@ -22,7 +22,6 @@ import org.opalj.br.instructions.INVOKEVIRTUAL
 import org.opalj.br.MethodDescriptor.ReadObjectDescriptor
 import org.opalj.br.MethodDescriptor.JustReturnsObject
 import org.opalj.tac.LazyTACUsingAIKey
-import org.opalj.tac.TACode
 import org.opalj.tac.VirtualMethodCall
 import org.opalj.tac.DUVar
 import org.opalj.tac.Assignment
@@ -108,19 +107,19 @@ class Serialization(implicit hermes: HermesConfig) extends DefaultFeatureQuery {
                 case i @ INVOKEVIRTUAL(declClass, "readObject", JustReturnsObject) if classHierarchy.isSubtypeOf(declClass, OIS)             ⇒ i
                 case i @ INVOKEVIRTUAL(declClass, "registerValidation", OISregisterValidation) if classHierarchy.isSubtypeOf(declClass, OIS) ⇒ i
             }
-            TACode(_, stmts, pcToIndex, _, _) = tacai(method)
+            tac = tacai(method)
         } {
             val pc = pcAndInvocation.pc
             val l = InstructionLocation(methodLocation, pc)
 
-            val invocation = stmts(pcToIndex(pc))
+            val invocation = tac.stmts(tac.properStmtIndexForPC(pc))
 
             if (invocation.astID == VirtualMethodCall.ASTID) {
                 if (invocation.asVirtualMethodCall.name == "writeObject")
                     handleWriteObject(
                         invocation.asVirtualMethodCall,
                         l,
-                        stmts,
+                        tac.stmts,
                         serializableTypes,
                         externalizableTypes,
                         notExternalizableTypes
@@ -133,7 +132,7 @@ class Serialization(implicit hermes: HermesConfig) extends DefaultFeatureQuery {
                         handleReadObject(
                             invocation.asAssignment,
                             l,
-                            stmts,
+                            tac.stmts,
                             serializableTypes,
                             externalizableTypes,
                             notExternalizableTypes


### PR DESCRIPTION
There is no caught exception instruction in bytecode, so in the three-address code, a CaughtException stmt will have the same pc as the next proper stmt. pcToIndex in this case returns the index of the CaughtException, but analyses will usually need the index of the next proper stmt.