### PR TITLE
Fix off-by-one error in ObjectType to ID mapping

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/Type.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Type.scala
@@ -1060,8 +1060,8 @@ object ObjectType {
     @volatile private[this] var objectTypes: Array[ObjectType] = new Array[ObjectType](0)
 
     private[this] def updateObjectTypes(): Unit = {
-        if (nextId.get >= objectTypes.length) {
-            val newObjectTypes = JArrays.copyOf(this.objectTypes, nextId.get + 1)
+        if (nextId.get > objectTypes.length) {
+            val newObjectTypes = JArrays.copyOf(this.objectTypes, nextId.get)
             cacheRWLock.readLock().lock()
             try {
                 cache.values.forEach { wot ⇒


### PR DESCRIPTION
Previously, the array would always be one entry longer than needed to accomodate all known object types, leading to null being return when looking up the very last object type added.