### PR TITLE
Allow merging of indirect callee parameters if they are equal

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/Callees.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/Callees.scala
@@ -299,10 +299,12 @@ sealed class ConcreteCallees(
             _incompleteCallSites ++ incompleteCallSites,
             _indirectCallReceivers.unionWith(
                 indirectCallReceivers,
-                (_, r, l) ⇒ {
+                (_, l, r) ⇒ {
                     r.unionWith(
                         l,
-                        (_, _, _) ⇒ throw new UnknownError("Indirect callee derived by two analyses")
+                        (_, vl, vr) ⇒
+                            if (vl == vr) vl
+                            else throw new UnknownError("Incompatible receivers for indirect call")
                     )
                 }
             ),
@@ -311,7 +313,9 @@ sealed class ConcreteCallees(
                 (_, r, l) ⇒ {
                     r.unionWith(
                         l,
-                        (_, _, _) ⇒ throw new UnknownError("Indirect callee derived by two analyses")
+                        (_, vl, vr) ⇒
+                            if (vl == vr) vl
+                            else throw new UnknownError("Incompatible parameters for indirect call")
                     )
                 }
             )


### PR DESCRIPTION
We didn't encounter this previously, but obviously it is possible for the same analysis to produce a call more than once if different receiver types resolve to the same target method. In this case, a merge is required.